### PR TITLE
play nice with commands that display files located inside .git/

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -35,6 +35,13 @@ set cpo&vim
 " is found.
 function! s:FindSCMDirectory(scm_type)
   let dir_current_file = expand("%:p:h")
+
+  " If we're inside of the scm dir (.git) treat it as a miss
+  " This makes vim-rooter play nice with plugins like fugitive
+  if match(dir_current_file, a:scm_type)
+    return ""
+  endif
+
   let scm_dir = finddir(a:scm_type, dir_current_file . ";")
   " If we're at the project root or we can't find one above us
   if scm_dir == a:scm_type || empty(scm_dir)


### PR DESCRIPTION
I was running into errors with vim-rooter when running fugitive's Glog command.  I modified FindSCMDirectory to return "" if you are currently inside of the scm_dir and this appears to have stopped vim-rooter from throwing an error when using :Glog.  

-Matt Margolis
