### PR TITLE
disable autochdir when changing to root

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -71,6 +71,9 @@ endfunction
 function! s:ChangeToRootDirectory()
   let root_dir = s:FindRootDirectory()
   if !empty(root_dir)
+    if exists('+autochdir') 
+      set noautochdir
+    endif
     if g:rooter_use_lcd ==# 1
       exe ":lcd " . root_dir
     else


### PR DESCRIPTION
Hi,

By default I use the 'autochdir' option to automatically cd to the directory of the current file. However when this option is enabled, the rooter plugin doesn't really work, as Vim will always change to the files' directory again. This patch disables the autochdir when the rooter plugin changes to the repo-root, so you have best-of-both worlds.

thx for the very nice plugin!
Jeroen
