### PR TITLE
remove autocmd from the plugin

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -4,14 +4,17 @@
 " Copyright 2010 Andrew Stewart, <boss@airbladesoftware.com>
 " Released under the MIT licence.
 "
-" This will happen automatically for typical Ruby webapp files.
-"
 " You can invoke it manually with <Leader>cd (usually \cd).
 " To change the mapping, put this in your .vimrc:
 "
 "     map <silent> <unique> <Leader>foo <Plug>RooterChangeToRootDirectory
 "
 " ... where <Leader>foo is your preferred mapping.
+"
+" You can also setup autocmd to automatically call :Rooter
+"
+"     autocmd BufEnter *.rb :Rooter  "only for Ruby files
+"     autocmd BufEnter * :Rooter     "for all files
 "
 " Options:
 "   let g:rooter_use_lcd = 1
@@ -97,7 +100,6 @@ noremap <SID>ChangeToRootDirectory :call <SID>ChangeToRootDirectory()<CR>
 "
 
 command! Rooter :call <SID>ChangeToRootDirectory()
-autocmd BufEnter *.rb,*.html,*.haml,*.erb,*.rjs,*.css,*.js :Rooter
 
 "
 " Boilerplate


### PR DESCRIPTION
Actually, setting autocmd in the plugin for Ruby projects came of as a little surprise to me. What if I prefer not to change directory automatically for any filetype, and just use <leader>cd instead?

So, I thought it would be better to decouple it from the plugin, and have the user set it according to his/her choice.

Of course this is not a very significant change. Just wanted to share my reasons here lest it should appeal to you too :).
