### PR TITLE
Fix for compatibility with Fugitive

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -43,6 +43,11 @@ endif
 " containing a <scm_type> directory, or an empty string if no such directory 
 " is found.
 function! s:FindSCMDirectory(scm_type)
+  " don't try to change directories when on a virtual filesystem (netrw, fugitive,...)
+  if match(expand('%:p'), '^\<.\+\>://.*') != -1
+    return ""
+  endif
+
   let dir_current_file = expand("%:p:h")
   let scm_dir = finddir(a:scm_type, dir_current_file . ";")
   " If we're at the project root or we can't find one above us


### PR DESCRIPTION
Hi,

I took another look into why Rooter gives errors while using the Fugitive plugin and I came up with a fix which seems to work.
The problem is that the fugitive plugin uses fugitive:///path/to/diff/.git/path/to/file.vim url's for various files. Rooter successfully finds the .git-directory inside that url and then tries to :cd to fugitive:///path/to/diff/, which Vim can't do. I found that the same problem occurs when opening a file from a http url (with netrw) if it has an accompanying .git directory on the server or in the url.
This patch adds a check inside the s:FindSCMDirectory function to first check if the full path to the file starts with <anything>:// and in this case returns an empty string so Rooter does not try to change directories at all.
I have been using Fugitive for a few hours now without any problems.

Jeroen
