### PR TITLE
Small change to make vim-rooter work on windows too

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -58,7 +58,7 @@ function! s:FindSCMDirectory(scm_type)
   if scm_dir == a:scm_type || empty(scm_dir)
     return ""
   else
-    return substitute(scm_dir, "/" . a:scm_type . "$", "", "")
+    return substitute(scm_dir, a:scm_type . "$", "", "")
   endif
 endfunction
 


### PR DESCRIPTION
On windows, vim-rooter used to change the directory to the DVCS data folder instead to the project's root.

It's easy to see why this was happening - the line I modified did not produce any substitution, because windows uses backslashes in file-system paths. It should be safe to keep the ending slash (whatever it is) in the path.
