### PR TITLE
fix re because this match() returns -1 if &iskeyword includs ':'

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -75,7 +75,7 @@ endif
 " is found.
 function! s:FindInCurrentPath(pattern)
   " Don't try to change directories when on a virtual filesystem (netrw, fugitive,...).
-  if match(expand('%:p'), '^\<.\+\>://.*') != -1
+  if match(expand('%:p'), '^\w\+://.*') != -1
     return ""
   endif
 


### PR DESCRIPTION
If &iskeyword include `:` (eg. .vim filetype), press `D` (show diffs) in [fugitive](https://github.com/tpope/vim-fugitive) window, and plugin shows an error below.

```
Error detected while processing function <SNR>70_ChangeToRootDirectory:                                                                                                                   
line    7:
E472: Command failed
Press ENTER or type command to continue
```

fugitive windows have paths such as `fugitive://path/to/filename`, and old re `^\<.\+\>` should match `fugitive`. But if &iskeyword has ':', this matches `fugitive:` and yields an error.
