### PR TITLE
Fix for a Windows-specific bug

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -103,20 +103,26 @@ endfunction
 " such directory or file is found.
 function! s:FindInCurrentPath(pattern)
   let dir_current_file = fnameescape(expand('%:p:h'))
-  let project_dir = ''
 
   if s:IsDirectory(a:pattern)
     let match = finddir(a:pattern, dir_current_file . ';')
+
+    if empty(match)
+      return ''
+    endif
+
+    " `match' always ends with '/' or '\' depending on platform hence the
+    " double ':h' is required to strip just the last component of path
+    return fnamemodify(match, ':p:h:h')
   else
     let match = findfile(a:pattern, dir_current_file . ';')
-  endif
 
-  if empty(match)
-    return ''
-  endif
+    if empty(match)
+      return ''
+    endif
 
-  let match = fnamemodify(match, ':p')
-  return substitute(match, a:pattern . '$', '', '')
+    return fnamemodify(match, ':p:h')
+  endif
 endfunction
 
 " Returns the root directory for the current file based on the list of


### PR DESCRIPTION
Using something like substitute(..., '.svn/', '') to strip last
component of path caused a do-nothing operation on Windows, where path
components are separated by '\'.  This lead to :cd to '.svn' directory,
instead of that one level up.

The fix consist of using fnamemodify(..., ':h:h') in place of
substitute(..., '.svn/', '').
