### PR TITLE
Add a help file

### DIFF
--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -1,0 +1,95 @@
+rooter.txt
+
+                        ____              __
+                       / __ \____  ____  / /____  _____
+                      / /_/ / __ \/ __ \/ __/ _ \/ ___/
+                     / _, _/ /_/ / /_/ / /_/  __/ /
+                    /_/ \_\\____/\____/\__/\___/_/
+
+
+==============================================================================
+CONTENTS                                                     |rooter-contents|
+
+    Introduction ................................ |rooter-introduction|
+    Use ......................................... |rooter-use|
+    Configuration ............................... |rooter-configuration|
+    Installation ................................ |rooter-installation|
+
+==============================================================================
+Introduction                                      *rooter* *rooter-introduction*
+
+Rooter is a Vim plugin which changes the working directory to the project root
+when you open a file.
+
+More accurately, it'll do this when you open a typical webapp file. These
+files are identified by their extension.
+
+The project root is identified by the presence of known directory, such as a
+VCS directory, or file, such as a Rakefile. Currently git, darcs, mercurial,
+bazaar, and subversion are supported.
+
+==============================================================================
+Use                                                               *rooter-use*
+
+By default you don't need to do anything: vim-rooter will change the working
+directory automatically.
+
+You can always invoke vim-rooter manually with <Leader>cd.
+
+==============================================================================
+Configuration                                           *rooter-configuration*
+                                                        *g:rooter_manual_only*
+                                                           *g:rooter_patterns*
+                                                            *g:rooter_use_lcd*
+                             *g:rooter_change_directory_for_non_project_files*
+
+You can change the manual-invocation mapping by adding this to your .vimrc:
+
+map <silent> <unique> <Leader>foo <Plug>RooterChangeToRootDirectory
+where <Leader>foo is the mapping you want.
+
+You can change the file extensions which trigger vim-rooter with autocommands
+in ~/.vim/after/plugin/vim-rooter.vim. You'll need to create this file, and
+possibly the directories, yourself.
+
+To add a file extension, e.g. foo: >
+
+    autocmd rooter BufEnter *.foo :Rooter
+<
+To remove a file extension, e.g. js: >
+
+    autocmd! rooter BufEnter *.js
+<
+To stop vim-rooter changing directory automatically, add this to your .vimrc: >
+
+    let g:rooter_manual_only = 1
+<
+You can set your own directory and file patterns like this: >
+
+    let g:rooter_patterns = ['Rakefile', '.git/']
+<
+Vim-rooter checks the patterns in the order given. So to work correctly with
+git submodules you should have .git before .git/.
+
+Setting your own patterns overwrites the defaults. Directories should have a
+trailing slash.
+
+You can have vim-rooter locally change directory (|:lcd|) instead of changing
+directory (|:cd|) by adding this to your .vimrc: >
+
+    let g:rooter_use_lcd = 1
+<
+When vim-rooter encounters a non-project file, it won't change directory by
+default. If you would instead like vim-rooter to change to the file's
+directory, do this: >
+
+    let g:rooter_change_directory_for_non_project_files = 1
+<
+==============================================================================
+Installation                                             *rooter-installation*
+
+Install into ~/.vim/plugin/rooter.vim or, if you're using Pathogen, into
+~/.vim/bundle/rooter.vim.
+
+==============================================================================
+vim:tw=78:sw=4:ts=8:ft=help:norl:


### PR DESCRIPTION
Add a doc that is as README.mkd is.

Then, we can use the help like:
- `:help rooter`
- `:help g:rooter_change_directory_for_non_project_files`.
