### PR TITLE
Added doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/tags
+


### PR DESCRIPTION
Stops the repo getting dirty when you're using submodules and pathogen, for example.
