### PR TITLE
Added g:rooter_disable_mapping

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -27,6 +27,10 @@ You can change the manual-invocation mapping by adding this to your `.vimrc`:
 
 where `<Leader>foo` is the mapping you want.
 
+To prevent vim-rooter from creating a mapping, do this:
+
+    let g:rooter_disable_map = 1
+
 You can change the file extensions which trigger vim-rooter with autocommands
 in `~/.vim/after/plugin/vim-rooter.vim`.  You'll need to create this file, and
 possibly the directories, yourself.

--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -39,6 +39,7 @@ You can always invoke vim-rooter manually with <Leader>cd.
 ==============================================================================
 Configuration                                           *rooter-configuration*
                                                         *g:rooter_manual_only*
+                                                        *g:rooter_disable_map*
                                                            *g:rooter_patterns*
                                                             *g:rooter_use_lcd*
                              *g:rooter_change_directory_for_non_project_files*
@@ -48,6 +49,10 @@ You can change the manual-invocation mapping by adding this to your .vimrc:
 map <silent> <unique> <Leader>foo <Plug>RooterChangeToRootDirectory
 where <Leader>foo is the mapping you want.
 
+To prevent vim-rooter from creating a mapping, do this: >
+
+    let g:rooter_disable_map = 1
+<
 You can change the file extensions which trigger vim-rooter with autocommands
 in ~/.vim/after/plugin/vim-rooter.vim. You'll need to create this file, and
 possibly the directories, yourself.

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -155,7 +155,7 @@ endfunction
 
 " Mappings and commands {{{
 
-if !hasmapto("<Plug>RooterChangeToRootDirectory")
+if !exists("g:rooter_disable_mapping") && !hasmapto("<Plug>RooterChangeToRootDirectory")
   map <silent> <unique> <Leader>cd <Plug>RooterChangeToRootDirectory
 endif
 noremap <unique> <script> <Plug>RooterChangeToRootDirectory <SID>ChangeToRootDirectory


### PR DESCRIPTION
Added an option to disable the mapping.
This is useful if the user wishes to define a function that calls Rooter instead of a direct mapping. [e.g.](https://github.com/rdnetto/vimrc/blob/master/vimrc#L327)