### PR TITLE
Unmap mapping in Select mode so it doesn’t interfere

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -157,6 +157,7 @@ endfunction
 
 if !hasmapto("<Plug>RooterChangeToRootDirectory")
   map <silent> <unique> <Leader>cd <Plug>RooterChangeToRootDirectory
+  sunmap <silent> <unique> <Leader>cd
 endif
 noremap <unique> <script> <Plug>RooterChangeToRootDirectory <SID>ChangeToRootDirectory
 noremap <SID>ChangeToRootDirectory :call <SID>ChangeToRootDirectory()<CR>


### PR DESCRIPTION
`map` and `vmap`, surprisingly, apply not only to Visual mode but also to [Select mode](http://vimdoc.sourceforge.net/htmldoc/visual.html#Select). (See [`:help mapmode-s`](http://vimdoc.sourceforge.net/htmldoc/map.html#mapmode-s).) However, this doesn’t make sense if the mapping contains a printable character, which it often does – it stops the user from typing that character and seeing the result immediately. So you have to use `sunmap` to remove it (or use `xmap` instead of `vmap`.)
