### PR TITLE
Add option for resolving symbolic links

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -97,6 +97,14 @@ If you don't want vim-rooter to echo the project directory, try this:
 let g:rooter_silent_chdir = 1
 ```
 
+By default, vim-rooter doesn't resolve symbolic links, so it will look for the
+project root from a link's location. If you want it to look from the location
+of a link's target instead, you can use:
+
+```viml
+let g:rooter_resolve_links = 1
+```
+
 ## Installation
 
 Install into `~/.vim/plugin/rooter.vim` or, if you're using Pathogen, into

--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -111,6 +111,12 @@ If you don't want vim-rooter to echo the project directory, try this: >
 
     let g:rooter_silent_chdir = 1
 <
+By default, vim-rooter doesn't resolve symbolic links, so it will look for the
+project root from a link's location. If you want it to look from the location
+of a link's target instead, you can use: >
+
+    let g:rooter_resolve_links = 1
+<
 
 ==============================================================================
 Installation                                             *rooter-installation*

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -35,6 +35,10 @@ if !exists('g:rooter_silent_chdir')
   let g:rooter_silent_chdir = 0
 endif
 
+if !exists('g:rooter_resolve_links')
+  let g:rooter_resolve_links = 0
+endif
+
 " }}}
 
 " Utility {{{
@@ -70,7 +74,11 @@ endfunction
 " directory containing the given directory or file, or an empty string if no
 " such directory or file is found.
 function! s:FindInCurrentPath(pattern)
-  let dir_current_file = fnameescape(expand('%:p:h'))
+  let current_file = expand('%:p')
+  if g:rooter_resolve_links
+    let current_file = resolve(current_file)
+  endif
+  let dir_current_file = fnameescape(fnamemodify(current_file, ':h'))
 
   if s:IsDirectory(a:pattern)
     let match = finddir(a:pattern, dir_current_file . ';')


### PR DESCRIPTION
vim-rooter can now optionally resolve symbolic links before searching
for the project root. This is useful when editing a file within a
project from a symbolic link outside.

Enabled with: `let g:rooter_resolve_links = 1`