### PR TITLE
Support changing to directory containing Makefile

### DIFF
--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -60,6 +60,7 @@ Configuration                                           *rooter-configuration*
                                                    *g:rooter_autocmd_patterns*
                                                             *g:rooter_use_lcd*
                              *g:rooter_change_directory_for_non_project_files*
+                                                     *g:rooter_chdir_makefile*
 
 You can change the manual-invocation mapping by adding this to your |vimrc|: >
 
@@ -117,6 +118,16 @@ of a link's target instead, you can use: >
 
     let g:rooter_resolve_links = 1
 <
+If you want vim-rooter to not change to your root-directory but instead change
+to the first directory in your path containing a Makefile, you can use: >
+
+    let g:rooter_chdir_makefile = 1
+<
+Specifying your own Makefile formats overwrites the defaults. You can use >
+
+    let g:rooter_patterns = g:rooter_makefile_patterns + [ 'hello.mk' ]
+<
+to append to the default patterns for makefile scripts.
 
 ==============================================================================
 Installation                                             *rooter-installation*


### PR DESCRIPTION
Added an option to support changing directory to the first directory of the

current path that containts a Makefile. If

    let g:rooter_chdir_makefile = 1

is enabled, and the current directory does not contain any Makefiles, vim-root
will traverse the directory path upwards until it finds a Makefile or encounters
the original project root (as would have been selected with
rooter_chdir_makefile == 0 )

For example, if the current working dir is <root>/a/b/c, where each
directory contains various files but directories a and b contain Makefiles,
 if rooter_chdir_makefile = 1, vim-root will
change the root directory to be  <root>/a/b (whereas with the option off, the
respective directory would be <root>)