### PR TITLE
Fixed finding of root directory on windows machines

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -73,6 +73,10 @@ function! s:ChangeDirectoryForBuffer()
 endfunction
 
 function! s:FindAncestor(pattern)
+  if !isdirectory(s:fd)
+    let s:fd = fnamemodify(s:fd, ':h')
+  endif
+
   if s:IsDirectory(a:pattern)
     let match = finddir(a:pattern, fnameescape(s:fd).';')
   else


### PR DESCRIPTION
#54 I'm assuming this must only be the case on Windows machines, but finddir and findfile don't seem to take paths to a file as the parameter, only to a directory.  I added a check before they're called to see if s:fd is a directory, and if not, it'll strip the file name off the end.  I assume this won't cause any problems, but if for some reason this breaks compatibility on another platform, let me know.