### PR TITLE
Preserve directory when open Vim without file argument

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -136,7 +136,9 @@ function! s:ChangeToRootDirectory()
     " Test against 1 for backwards compatibility
     if g:rooter_change_directory_for_non_project_files == 1 ||
           \ g:rooter_change_directory_for_non_project_files ==? 'current'
-      call s:ChangeDirectory(fnamemodify(s:fd, ':h'))
+      if expand('%') != ''
+        call s:ChangeDirectory(fnamemodify(s:fd, ':h'))
+      endif
     elseif g:rooter_change_directory_for_non_project_files ==? 'home'
       call s:ChangeDirectory($HOME)
     endif


### PR DESCRIPTION
Hello, thank you for a great plugin!

This PR is about to handle the corner case:

1. Have `let g:rooter_change_directory_for_non_project_files = 'current'`
2. `mkdir /tmp/foo && cd /tmp/foo`
3. `vim` -> sets directory to `/tmp` instead of `/tmp/foo`

Notice please, I didn't touch tests.
