### PR TITLE
Fix FindRootDirectory return empty while current directory is not project root

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -151,6 +151,10 @@ endfunction
 function! FindRootDirectory()
   let s:fd = expand('%:p')
 
+  if empty(s:fd)
+    let s:fd = getcwd()
+  endif
+
   if g:rooter_resolve_links
     let s:fd = resolve(s:fd)
   endif


### PR DESCRIPTION
ex:
```bash
cd vim-rooter/plugin
vim
```
and then
```vim
:echo FindRootDirectory()
```