### PR TITLE
Change root directory, when file was opened by `vim --remote-silent`

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -182,7 +182,7 @@ command! Rooter :call <SID>ChangeToRootDirectory()
 if !exists('g:rooter_manual_only')
   augroup rooter
     autocmd!
-    autocmd VimEnter,BufEnter * :Rooter
+    autocmd VimEnter,BufReadPost,BufEnter * :Rooter
     autocmd BufWritePost * :call setbufvar('%', 'rootDir', '') | :Rooter
   augroup END
 endif


### PR DESCRIPTION
When file was opened by `vim --remote-silent <file>` command, root directory wasn't changed.
Rooter should change directory, when a file was opened by `vim --remote-silent <file>`. But it didn't.