### PR TITLE
Add 'nested' flag to autocmds

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -192,8 +192,8 @@ command! Rooter :call <SID>ChangeToRootDirectory()
 if !exists('g:rooter_manual_only') || !g:rooter_manual_only
   augroup rooter
     autocmd!
-    autocmd VimEnter,BufEnter * :Rooter
-    autocmd BufWritePost * :call setbufvar('%', 'rootDir', '') | :Rooter
+    autocmd VimEnter,BufEnter * nested :Rooter
+    autocmd BufWritePost * nested :call setbufvar('%', 'rootDir', '') | :Rooter
   augroup END
 endif
 


### PR DESCRIPTION
When autocmds currently fire, they don't cascade their actions to later autocmds as nesting is disabled by default.

I've begun using neovim-gtk, and an annoying behaviour is that its browser sidebar fails to change to the project root, meaning every subsequent file I try to open is opened with the wrong relative path.

This is due to the DirChanged event not being fired, as rooter changes directory inside an existing autocmd. Changing the autocmd definitions to permit nesting resolves this issue. DirChanged is fired as expected.

I couldn't find any other discussions regarding 'nested' on the repo, issues or pull requests. I couldn't find an immediate good reason that rooter shouldn't trigger these events either. I've only trivially tested this change locally though and am only a vim amateur.