### PR TITLE
Exclude directories for nested repositories.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -97,6 +97,16 @@ By default vim-rooter doesn't resolve symbolic links.  To resolve links:
 let g:rooter_resolve_links = 1
 ```
 
+Vim-rooter can be disabled if certain directory or file name is on the path. It
+is very useful if you have nested `.git` repositories and you do not want to
+change your root directory.
+
+```viml
+let g:rooter_excludes = ['extras']
+```
+
+Above will be executed on path /usr/project/lib but not on
+/usr/project/lib/extras. Assuming both are git repositories.
 
 ## Using root-finding functionality in other scripts
 

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -26,6 +26,10 @@ if !exists('g:rooter_targets')
   let g:rooter_targets = '/,*'
 endif
 
+if !exists('g:rooter_excludes')
+  let g:rooter_excludes = []
+endif
+
 if !exists('g:rooter_change_directory_for_non_project_files')
   let g:rooter_change_directory_for_non_project_files = ''
 endif
@@ -52,7 +56,18 @@ function! s:ChangeDirectory(directory)
 endfunction
 
 function! s:IsDirectory(pattern)
-  return a:pattern[-1:] == '/'
+  let bypass = 0
+  for pattern in g:rooter_excludes
+    if stridx(s:fd, pattern) > -1
+      let bypass = 1
+      break
+    endif
+  endfor
+  if bypass
+    return 0
+  else
+    return a:pattern[-1:] == '/'
+  endif
 endfunction
 
 function! s:ChangeDirectoryForBuffer()


### PR DESCRIPTION
Sometimes projects you control have subprojects/submodules that are there only for reference or testing purposes and you do not want to change your root directory to those repositories to be able to use proper tags and completion.