### PR TITLE
Add option g:rooter_check_all_patterns to check every pattern and use the deepest subdirectory

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -75,11 +75,17 @@ To specify how to identify a project's root directory:
 let g:rooter_patterns = ['Rakefile', '.git/']
 ```
 
-Vim-rooter checks the patterns depth (height?) first.  Directories must have a trailing slash.  To work correctly with git submodules place `.git` before `.git/`.
-
 If a rooter pattern directory is one of the current file's ancestors, it is taken to be the project root.  Otherwise, vim-rooter looks for an ancestor containing the given pattern directory/file.
 
 Note that using a symlink as a rooter pattern will probably not do what you want.  Vim resolves symlinks when evaluating file paths so you will end up with the symlink source regarded as the root, not its target.
+
+By default, vim-rooter checks the patterns depth (height?) first.  Directories must have a trailing slash.  To work correctly with git submodules place `.git` before `.git/`.
+
+If instead you'd like each pattern to be checked so that the deepest subdirectory is always used:
+
+```viml
+let g:rooter_check_all_patterns = 1
+```
 
 To change directory for the current window only (`:lcd`):
 

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -116,13 +116,18 @@ function! s:FindAncestor(pattern)
 endfunction
 
 function! s:SearchForRootDirectory()
+  let max_len = 0
+  let max_len_res = ''
   for pattern in g:rooter_patterns
     let result = s:FindAncestor(pattern)
     if !empty(result)
-      return result
+      if len(result) > max_len
+        let max_len = len(result)
+        let max_len_res = result
+      endif
     endif
   endfor
-  return ''
+  return max_len_res
 endfunction
 
 function! s:RootDirectory()

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -38,6 +38,10 @@ if !exists('g:rooter_resolve_links')
   let g:rooter_resolve_links = 0
 endif
 
+if !exists('g:rooter_check_all_patterns')
+  let g:rooter_check_all_patterns = 0
+endif
+
 function! s:ChangeDirectory(directory)
   if a:directory !=# getcwd()
     let cmd = g:rooter_use_lcd == 1 ? 'lcd' : 'cd'
@@ -121,9 +125,13 @@ function! s:SearchForRootDirectory()
   for pattern in g:rooter_patterns
     let result = s:FindAncestor(pattern)
     if !empty(result)
-      if len(result) > max_len
-        let max_len = len(result)
-        let max_len_res = result
+      if !g:rooter_check_all_patterns 
+        return result
+      else
+        if len(result) > max_len
+          let max_len = len(result)
+          let max_len_res = result
+        endif
       endif
     endif
   endfor


### PR DESCRIPTION
This is work on top of https://github.com/airblade/vim-rooter/pull/93. I've just added a configuration option `g:rooter_check_all_patterns` in order to enable the behaviour described in that pull request.