### PR TITLE
Add a RooterToggle command to pause rooter

### DIFF
--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -15,6 +15,7 @@ CONTENTS                                                     |rooter-contents|
     Non-project files ............................. |rooter-non-project-files|
     Configuration ..................................... |rooter-configuration|
     Using root-finding functionality in other scripts .. |rooter-finding-root|
+    Pausing Rooter .......................................... |pausing-rooter|
     Installation ....................................... |rooter-installation|
 
 ==============================================================================
@@ -120,6 +121,12 @@ If that's all you need you can turn off the directory-changing behaviour with:
 >
     let g:rooter_manual_only = 1
 <
+
+==============================================================================
+Pausing Rooter                                                *pausing-rooter*
+
+To temporarily pause vim-rooter you can use the |RooterToggle| command. Rooter
+will not change directories until |RooterToggle| is called again.
 
 ==============================================================================
 Installation                                             *rooter-installation*

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -136,7 +136,17 @@ function! s:RootDirectory()
   return root_dir
 endfunction
 
+let g:rooter_paused = 0
+
+function! s:RooterToggle()
+  let g:rooter_paused = !g:rooter_paused
+endfunction
+
 function! s:ChangeToRootDirectory()
+  if g:rooter_paused
+    return
+  endif
+
   " A directory will always have a trailing path separator.
   let s:fd = expand('%:p')
 
@@ -188,6 +198,7 @@ function! FindRootDirectory()
 endfunction
 
 command! -bar Rooter :call <SID>ChangeToRootDirectory()
+command! -bar RooterToggle :call <SID>RooterToggle()
 
 if !exists('g:rooter_manual_only') || !g:rooter_manual_only
   augroup rooter


### PR DESCRIPTION
This can be used in scenarios where you don't want to change to the
root project, for example in combination with the
vim-terminal-help-plugin