### PR TITLE
Optionally use :tcd instead of :cd or :lcd

### DIFF
--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -70,6 +70,7 @@ Configuration                                           *rooter-configuration*
                                                         *g:rooter_manual_only*
                                                            *g:rooter_patterns*
                                                             *g:rooter_use_lcd*
+                                                            *g:rooter_use_tcd*
                                                        *g:rooter_silent_chdir*
                                                       *g:rooter_resolve_links*
 
@@ -99,6 +100,10 @@ containing the given pattern directory/file.
 To change directory for the current window only (|:lcd|): >
 
     let g:rooter_use_lcd = 1
+<
+To change directory for the current tab only (vim 8+/neovim only) (|:tcd|): >
+
+    let g:rooter_use_tcd = 1
 <
 To stop vim-rooter echoing the project directory: >
 

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -18,6 +18,10 @@ if !exists('g:rooter_use_lcd')
   let g:rooter_use_lcd = 0
 endif
 
+if !exists('g:rooter_use_tcd')
+  let g:rooter_use_tcd = 0
+endif
+
 if !exists('g:rooter_patterns')
   let g:rooter_patterns = ['.git', '.git/', '_darcs/', '.hg/', '.bzr/', '.svn/']
 endif
@@ -40,7 +44,13 @@ endif
 
 function! s:ChangeDirectory(directory)
   if a:directory !=# getcwd()
-    let cmd = g:rooter_use_lcd == 1 ? 'lcd' : 'cd'
+    if g:rooter_use_tcd == 1 && v:version >= 800
+      let cmd = 'tcd'
+    elseif g:rooter_use_lcd == 1
+      let cmd = 'lcd'
+    else
+      let cmd='cd'
+    endif
     execute ':'.cmd fnameescape(a:directory)
     if !g:rooter_silent_chdir
       echo 'cwd: '.a:directory


### PR DESCRIPTION
Allow changing the current directory for tabs only.

---
It doesn't make much sense for users to use both:
`let g:rooter_use_tcd = 1` and `let g:rooter_use_lcd = 1`
but regardless, I made `g:rooter_use_tcd` have higher priority over `g:rooter_use_lcd` since the tab's current dir is more general and a window will override that with its own local current dir.