### PR TITLE
Set cwd to project-root even if opened file is inside .git/ (#110)

### DIFF
--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -92,8 +92,7 @@ function! s:FindAncestor(pattern)
     let &suffixesadd = _suffixesadd
   endif
   
-  let match = substitute(match, "/*".a:pattern, "", "")
-  return match
+  return substitute(match, "/*".a:pattern, "", "")
 endfunction
 
 function! s:SearchForRootDirectory()

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -86,34 +86,14 @@ function! s:FindAncestor(pattern)
 
   if s:IsDirectory(a:pattern)
     let match = finddir(a:pattern, fd_dir_escaped.';')
-    let match = substitute(match, "/".a:pattern.".*", "", "")
   else
     let [_suffixesadd, &suffixesadd] = [&suffixesadd, '']
     let match = findfile(a:pattern, fd_dir_escaped.';')
     let &suffixesadd = _suffixesadd
   endif
-
-  if empty(match)
-    return ''
-  endif
-
-  if s:IsDirectory(a:pattern)
-    " If the directory we found (`match`) is part of the file's path
-    " it is the project root and we return it.
-    "
-    " Compare with trailing path separators to avoid false positives.
-    if stridx(fnamemodify(fd_dir, ':p'), fnamemodify(match, ':p')) == 0
-      return fnamemodify(match, ':p:h')
-
-    " Else the directory we found (`match`) is a subdirectory of the
-    " project root, so return match's parent.
-    else
-      return fnamemodify(match, ':p:h:h')
-    endif
-
-  else
-    return fnamemodify(match, ':p:h')
-  endif
+  
+  let match = substitute(match, "/*".a:pattern, "", "")
+  return match
 endfunction
 
 function! s:SearchForRootDirectory()

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -86,6 +86,7 @@ function! s:FindAncestor(pattern)
 
   if s:IsDirectory(a:pattern)
     let match = finddir(a:pattern, fd_dir_escaped.';')
+    let match = substitute(match, "/".a:pattern.".*", "", "")
   else
     let [_suffixesadd, &suffixesadd] = [&suffixesadd, '']
     let match = findfile(a:pattern, fd_dir_escaped.';')

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -92,7 +92,11 @@ function! s:FindAncestor(pattern)
     let &suffixesadd = _suffixesadd
   endif
   
-  return substitute(match, "/*".a:pattern, "", "")
+  let match = substitute(match, a:pattern."$", "", "")
+  if empty(match)
+    return ''
+  endif
+  return fnamemodify(match, ':p:h')
 endfunction
 
 function! s:SearchForRootDirectory()


### PR DESCRIPTION
https://github.com/airblade/vim-rooter/blob/d64f3e04df9914e784508019a1a1f291cbb40bd4/plugin/rooter.vim#L88

The function `finddir` returns the path of the first found match with the given pattern. If the pattern is part of the literal `fd_dir_escaped`-string then `finddir` returns the pattern as the root. This means if `.git/` is the pattern and `fd_dir_escaped` is `/home/user/project/.git/file` then `finddir` will return `/home/user/project/.git`. This PR makes sure that `/home/user/project` is the actual result.

Fixes #110