### PR TITLE
Add support for direct subdirectory

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -7,6 +7,7 @@ The project root can be identified by:
 - being a known directory;
 - having a known directory or file;
 - being a subdirectory of a known directory.
+- being a direct subdirectory of a known directory
 
 You can also exclude directories.
 
@@ -68,6 +69,11 @@ To specify the root has a certain directory as an ancestor (useful for excluding
 let g:rooter_patterns = ['^fixtures']
 ```
 
+To specify the root has a certain directory as a direct ancestor (useful when you put working projects in a common folder). prefix it with>:
+
+```viml
+let g:rooter_patterns = ['>Latex']
+```
 To exclude a pattern, prefix it with `!`.
 
 ```viml

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -143,6 +143,8 @@ function s:match(dir, pattern)
     return s:is(a:dir, a:pattern[1:])
   elseif a:pattern[0] == '^'
     return s:sub(a:dir, a:pattern[1:])
+  elseif a:pattern[0] == '>'
+    return s:directsub(a:dir, a:pattern[1:])
   else
     return s:has(a:dir, a:pattern)
   endif
@@ -182,6 +184,14 @@ function! s:sub(dir, identifier)
   return 0
 endfunction
 
+" Return true if identifier is a direct ancestor of dir, false otherwise
+"
+" dir        - full path to a directory
+" identifier - a directory name
+function! s:directsub(dir, identifier)
+  let path = s:parent(a:dir)
+    return fnamemodify(path, ':t') ==# a:identifier
+endfunction
 
 " Returns full path of directory of current file name (which may be a directory).
 function! s:current()


### PR DESCRIPTION
This is useful when user put working projects in a common folder. For example, all Latex projects in a folder `Latex`.