### PR TITLE
Respect user's &autochdir for not triggered buffer

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -22,7 +22,7 @@ You can turn this off (see below) and use the `:Rooter` command to invoke Rooter
 
 When Rooter changes the working directory it emits the autocmd user event `RooterChDir`.
 
-Rooter will unset `&autochdir` if it's set.
+For triggered buffers, rooter will unset `&autochdir` if it's set. For other buffers, rooter respect user's setting of `&autochdir`.
 
 
 ## Configuration

--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -46,8 +46,7 @@ Rooter manually.
 When Rooter changes the working directory it emits the |autocmd| |User| event
 `RooterChDir`.
 
-Rooter will unset 'autochdir' if it's set.
-
+For triggered buffers, rooter will unset `&autochdir` if it's set. For other buffers, rooter respect user's setting of `&autochdir`.
 
 ==============================================================================
 Configuration                                           *rooter-configuration*

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -14,7 +14,9 @@ if !exists('g:rooter_manual_only')
   let g:rooter_manual_only = 0
 endif
 
+let s:user_autochdir=0
 if exists('+autochdir') && &autochdir && !g:rooter_manual_only
+  let s:user_autochdir=1
   set noautochdir
 endif
 
@@ -66,7 +68,14 @@ augroup END
 
 
 function! s:rooter()
-  if !s:activate() | return | endif
+  if !s:activate() 
+    if s:user_autochdir
+      setl autochdir
+    endif
+    return 
+  endif
+
+  set noautochdir
 
   let root = getbufvar('%', 'rootDir')
   if empty(root)


### PR DESCRIPTION
For buffers that won't trigger rooter, we can respect user's &autochdir
setting for them unchanged.