### PR TITLE
add `package.json` to the default root patterns

### DIFF
--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -65,7 +65,7 @@ Default: '/,*'
 ------------------------------------------------------------------------------
 How to identify a root directory                           *g:rooter_patterns*
 
-Default: ['.git', '_darcs', '.hg', '.bzr', '.svn', 'Makefile']
+Default: ['.git', '_darcs', '.hg', '.bzr', '.svn', 'Makefile', 'package.json']
 
 Set `g:rooter_patterns` to a list of identifiers.  They are checked breadth-
 first as Rooter walks up the directory tree and the first match is used.

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -28,7 +28,7 @@ if !exists('g:rooter_cd_cmd')
 endif
 
 if !exists('g:rooter_patterns')
-  let g:rooter_patterns = ['.git', '_darcs', '.hg', '.bzr', '.svn', 'Makefile']
+  let g:rooter_patterns = ['.git', '_darcs', '.hg', '.bzr', '.svn', 'Makefile', 'package.json']
 endif
 
 if !exists('g:rooter_targets')


### PR DESCRIPTION
Hey, thanks for this plugin, really useful. 

The `packege.json` file is really common pattern for node projects. I know I can customize the root patterns with `let g:rooter_patterns`  but I think it is worth it to have it in the defaults.