### PR TITLE
Support native lists and negative patterns for `g:rooter_targets`

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -30,12 +30,19 @@ Rooter will unset `&autochdir` if it's set.
 
 ### Which buffers trigger Rooter
 
-By default all files and directories trigger Rooter.  Configure a comma separated list of patterns to specify which files trigger.  Include `/` to trigger on directories.  For example:
+By default all files and directories trigger Rooter.  Alternatively, set `g:rooter_targets` to a list of file path patterns which should trigger Rooter. Use a literal `/` to match directory buffers. For example:
 
 ```viml
 " Everything (default)
-let g:rooter_targets = '/,*'
+let g:rooter_targets = ['/', '*']
 
+" Directories and everything under /home
+let g:rooter_targets = ['/', '/home/*']
+```
+
+Comma-separated lists are also accepted:
+
+```viml
 " All files
 let g:rooter_targets = '*'
 

--- a/README.mkd
+++ b/README.mkd
@@ -40,6 +40,13 @@ let g:rooter_targets = ['/', '*']
 let g:rooter_targets = ['/', '/home/*']
 ```
 
+Patterns are tried in order until one of them matches. To specify a negative pattern, prefix it with a `!`. If no patterns match, Rooter is not triggered:
+
+```viml
+" Everything (default), except files under /tmp
+let g:rooter_targets = ['!/tmp/*', '/', '*']
+```
+
 Comma-separated lists are also accepted:
 
 ```viml

--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -60,6 +60,11 @@ Rooter. Use a literal `/` to match directory buffers. For example:
 >
     let g:rooter_targets = ['/', '/home/*']
 <
+Patterns are tried in order until one of them matches. To specify a negative
+pattern, prefix it with a `!`. If no patterns match, Rooter is not triggered:
+>
+    let g:rooter_targets = ['!/tmp/*', '/', '*']
+<
 A comma-separated list is also accepted instead of a native list:
 >
     let g:rooter_targets = '/,*.rb,*.haml,*.js'

--- a/doc/rooter.txt
+++ b/doc/rooter.txt
@@ -54,13 +54,17 @@ Configuration                                           *rooter-configuration*
 
 Which buffers trigger Rooter                                *g:rooter_targets*
 
-By default all files and directories trigger Rooter.  Configure a comma
-separated list of patterns to specify which files trigger.  Include "/" to
-trigger on directories.  For example:
+By default all files and directories trigger Rooter.  Alternatively, set
+`g:rooter_targets` to a list of file path patterns which should trigger
+Rooter. Use a literal `/` to match directory buffers. For example:
+>
+    let g:rooter_targets = ['/', '/home/*']
+<
+A comma-separated list is also accepted instead of a native list:
 >
     let g:rooter_targets = '/,*.rb,*.haml,*.js'
 <
-Default: '/,*'
+Default: ['/', '*']
 
 ------------------------------------------------------------------------------
 Which buffer types trigger Rooter                          *g:rooter_buftypes*

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -119,8 +119,13 @@ function! s:activate()
   if !exists('*glob2regpat') | return 1 | endif
 
   for p in filter(copy(patterns), 'v:val != "/"')
+    if p[0] == '!'
+      let [p, verdict] = [p[1:], 0]
+    else
+      let [p, verdict] = [p, 1]
+    endif
     if fn =~ glob2regpat(p)
-      return 1
+      return verdict
     endif
   endfor
 

--- a/plugin/rooter.vim
+++ b/plugin/rooter.vim
@@ -36,7 +36,7 @@ if !exists('g:rooter_patterns')
 endif
 
 if !exists('g:rooter_targets')
-  let g:rooter_targets = '/,*'
+  let g:rooter_targets = ['/', '*']
 endif
 
 if !exists('g:rooter_change_directory_for_non_project_files')
@@ -102,7 +102,11 @@ endfunction
 function! s:activate()
   if index(g:rooter_buftypes, &buftype) == -1 | return 0 | endif
 
-  let patterns = split(g:rooter_targets, ',')
+  if type(g:rooter_targets) == type([])
+    let patterns = g:rooter_targets
+  else
+    let patterns = split(g:rooter_targets, ',')
+  endif
   let fn = s:current_file()
 
   " directory


### PR DESCRIPTION
1. Similar to all other `g:rooter_*` variables that are semantically lists, make `g:rooter_targets` accept a native list data type.
2. Add support for negative patterns, e.g. `g:rooter_targets = ['!/tmp/*', '/', '*']` to blacklist paths under `/tmp`.

The latter is useful together with `let g:rooter_change_directory_for_non_project_files = 'current'` to prevent Rooter from pointlessly cd'ing on temporary files where the editor is transparently invoked for the user, e.g. Zsh's `edit-command-line` widget.